### PR TITLE
fix: include standalone .next build in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "files": [
     "bin/",
     ".next/standalone/",
+    ".next/standalone/.next/",
     ".next/static/",
     "public/",
     "hermes.version.json",


### PR DESCRIPTION
## Summary
- npm strips dotfolders from `files` globs by default, so `.next/standalone/.next/` was excluded from the published package
- This caused `next start` to fail with "Could not find a production build" because `BUILD_ID` and server chunks were missing
- Adding `.next/standalone/.next/` explicitly to the files array ensures the nested build output is included in the npm tarball

## The bug
When installed via `npx @euraika-labs/pan-ui start`, the app fails with:
```
[Error: Could not find a production build in the './.next' directory.
Try building your app with 'next build' before starting the production server.]
```

## The fix
One-line change to `package.json`:
```diff
  "files": [
    "bin/",
    ".next/standalone/",
+   ".next/standalone/.next/",
    ".next/static/",
```

## Test plan
- [x] Built from source, verified `.next/standalone/.next/BUILD_ID` exists
- [x] Ran standalone server directly — serves on port 3199
- [ ] Publish new npm version and test via `npx @euraika-labs/pan-ui start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)